### PR TITLE
Caliburn Container Now Being Called

### DIFF
--- a/IocPerformance/Program.cs
+++ b/IocPerformance/Program.cs
@@ -15,7 +15,7 @@ namespace IocPerformance
             {
                 Tuple.Create<string, IContainerAdapter>("No", new NoContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("AutoFac", new AutofacContainerAdapter()),
-                Tuple.Create<string, IContainerAdapter>("Caliburn.Micro", new CatelContainerAdapter()),
+                Tuple.Create<string, IContainerAdapter>("Caliburn.Micro", new CaliburnMicroContainer()),
                 Tuple.Create<string, IContainerAdapter>("Catel", new CatelContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("Dynamo", new DynamoContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("Funq", new FunqContainerAdapter()),


### PR DESCRIPTION
The CaliburnMicroContainer is now being added to the list in the Main method. There was a bug in which the Caliburn label was being populated with the Catel container. 
