### PR TITLE
Changed to resolve using Type instead of Generics, as this is the most basic and common way of resolving

### DIFF
--- a/IocPerformance/Adapters/AutofacContainerAdapter.cs
+++ b/IocPerformance/Adapters/AutofacContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Autofac;
 using Autofac.Extras.DynamicProxy2;
@@ -48,14 +49,14 @@ namespace IocPerformance.Adapters
             this.container = autofacContainerBuilder.Build();
         }
 
-        public T Resolve<T>() where T : class
+        public object Resolve(Type type)
         {
-            return this.container.Resolve<T>();
+            return this.container.Resolve(type);
         }
 
-        public T ResolveProxy<T>() where T : class
+        public object ResolveProxy(Type type)
         {
-            return this.container.Resolve<T>();
+            return this.container.Resolve(type);
         }
 
         public void Dispose()

--- a/IocPerformance/Adapters/CaliburnMicroContainerAdapter.cs
+++ b/IocPerformance/Adapters/CaliburnMicroContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Caliburn.Micro;
 
@@ -34,15 +35,15 @@ namespace IocPerformance.Adapters
                 (ITransient)ioc.GetInstance(typeof(ITransient), null)));
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return (T)this.container.GetInstance(typeof(T), null);
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetInstance(type, null);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return (T)this.container.GetInstance(typeof(T), null);
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetInstance(type, null);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/CatelContainerAdapter.cs
+++ b/IocPerformance/Adapters/CatelContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Catel.IoC;
 
@@ -36,15 +37,15 @@ namespace IocPerformance.Adapters
             container = serviceLocator;
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return container.ResolveType<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.ResolveType(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return container.ResolveType<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.ResolveType(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/DynamoContainerAdapter.cs
+++ b/IocPerformance/Adapters/DynamoContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Dynamo.Ioc;
 
@@ -33,15 +34,15 @@ namespace IocPerformance.Adapters
             this.container.Compile();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/FFastInjectorContainerAdapter.cs
+++ b/IocPerformance/Adapters/FFastInjectorContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using fFastInjector;
 
@@ -30,15 +31,15 @@ namespace IocPerformance.Adapters
             Injector.SetResolver<ICombined, Combined>();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return Injector.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return Injector.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return Injector.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return Injector.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/FunqContainerAdapter.cs
+++ b/IocPerformance/Adapters/FunqContainerAdapter.cs
@@ -1,10 +1,13 @@
-﻿using Funq;
+﻿using System;
+using System.Reflection;
+using Funq;
 
 namespace IocPerformance.Adapters
 {
     public sealed class FunqContainerAdapter : IContainerAdapter
     {
         private Container container;
+		private MethodInfo _methodInfo;
 
         public string Version
         {
@@ -26,17 +29,24 @@ namespace IocPerformance.Adapters
                 ioc.Resolve<ISingleton>(),
                 ioc.Resolve<ITransient>()))
                 .ReusedWithin(Funq.ReuseScope.None);
+
+			Func<Object> pointer = container.Resolve<Object>;
+			_methodInfo = pointer.Method.GetGenericMethodDefinition();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			// It only provides a generic Resolve<>() method.
+			var genericMethod = _methodInfo.MakeGenericMethod(new Type[] { type });
+			return genericMethod.Invoke(container, new object[] { });
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			// It only provides a generic Resolve<>() method.
+			var genericMethod = _methodInfo.MakeGenericMethod(new Type[] { type });
+			return genericMethod.Invoke(container, new object[] { });
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/GriffinContainerAdapter.cs
+++ b/IocPerformance/Adapters/GriffinContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Griffin.Container;
 using IocPerformance.Interception;
@@ -43,15 +44,15 @@ namespace IocPerformance.Adapters
             this.containerWithLoggingInterception = containerWithLoggingInterception;
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.containerWithLoggingInterception.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.containerWithLoggingInterception.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/HiroContainerAdapter.cs
+++ b/IocPerformance/Adapters/HiroContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Hiro;
 using Hiro.Containers;
@@ -35,15 +36,15 @@ namespace IocPerformance.Adapters
             this.container = map.CreateContainer();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetInstance(type, null);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetInstance(type, null);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/IContainerAdapter.cs
+++ b/IocPerformance/Adapters/IContainerAdapter.cs
@@ -6,9 +6,8 @@ namespace IocPerformance.Adapters
     {
         void Prepare();
 
-        T Resolve<T>() where T : class;
-
-        T ResolveProxy<T>() where T : class;
+	    object Resolve(Type type);
+	    object ResolveProxy(Type type);
 
         string Version { get; }
 

--- a/IocPerformance/Adapters/LightCoreContainerAdapter.cs
+++ b/IocPerformance/Adapters/LightCoreContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using LightCore;
 using LightCore.Lifecycle;
@@ -35,15 +36,15 @@ namespace IocPerformance.Adapters
             this.container = builder.Build();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/LightInjectContainerAdapter.cs
+++ b/IocPerformance/Adapters/LightInjectContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace IocPerformance.Adapters
@@ -30,15 +31,15 @@ namespace IocPerformance.Adapters
             container.Register<ICombined>(c => new Combined(c.GetInstance<ISingleton>(), c.GetInstance<ITransient>()), new PerRequestLifeTime());
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/LinFuContainerAdapter.cs
+++ b/IocPerformance/Adapters/LinFuContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using LinFu.IoC;
 
@@ -32,15 +33,15 @@ namespace IocPerformance.Adapters
             this.container.Inject<ICalculator>().Using<Calculator>().OncePerRequest();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.GetService<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetService(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.GetService<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetService(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/MefContainerAdapter.cs
+++ b/IocPerformance/Adapters/MefContainerAdapter.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.Composition.Hosting;
+﻿using System;
+using System.ComponentModel.Composition.Hosting;
+using System.Linq;
 
 namespace IocPerformance.Adapters
 {
@@ -19,15 +21,15 @@ namespace IocPerformance.Adapters
             this.container = new CompositionContainer(catalog);
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.GetExportedValue<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetExports(type, null, null).First().Value;
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.GetExportedValue<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetExports(type, null, null).First().Value;
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/MicroSliverContainerAdapter.cs
+++ b/IocPerformance/Adapters/MicroSliverContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using MicroSliver;
 
@@ -31,15 +32,15 @@ namespace IocPerformance.Adapters
             this.container.Map<ICombined, Combined>();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Get<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetByType(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Get<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetByType(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/MugenContainerAdapter.cs
+++ b/IocPerformance/Adapters/MugenContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using MugenInjection;
 
@@ -32,15 +33,15 @@ namespace IocPerformance.Adapters
             this.container.Bind<ICombined>().To<Combined>().InTransientScope();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Get<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Get(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Get<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Get(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/MunqContainerAdapter.cs
+++ b/IocPerformance/Adapters/MunqContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Munq;
 using Munq.LifetimeManagers;
@@ -34,15 +35,15 @@ namespace IocPerformance.Adapters
             this.container.Register<ICombined, Combined>().WithLifetimeManager(new AlwaysNewLifetime());
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/NinjectContainerAdapter.cs
+++ b/IocPerformance/Adapters/NinjectContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Ninject;
 
@@ -31,15 +32,15 @@ namespace IocPerformance.Adapters
             this.container.Bind<ICombined>().To<Combined>().InTransientScope();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Get<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Get(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Get<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Get(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/NoContainerAdapter.cs
+++ b/IocPerformance/Adapters/NoContainerAdapter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using IocPerformance.Interception;
 
 namespace IocPerformance.Adapters
 {
@@ -21,15 +20,15 @@ namespace IocPerformance.Adapters
             container[typeof(ICombined)] = () => new Combined(singleton, new Transient());
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return (T)this.container[typeof(T)]();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container[type]();
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return (T)this.container[typeof(T)]();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container[type]();
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/PetiteContainerAdapter.cs
+++ b/IocPerformance/Adapters/PetiteContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Petite;
 
@@ -34,15 +35,15 @@ namespace IocPerformance.Adapters
                 c.Resolve<ITransient>()));
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/SimpleInjectorContainerAdapter.cs
+++ b/IocPerformance/Adapters/SimpleInjectorContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using IocPerformance.Interception;
 using SimpleInjector;
@@ -39,15 +40,15 @@ namespace IocPerformance.Adapters
             this.container.Verify();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/SpeediocContainerAdapter.cs
+++ b/IocPerformance/Adapters/SpeediocContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Speedioc;
 using Speedioc.Core;
@@ -43,15 +44,15 @@ namespace IocPerformance.Adapters
             container = containerBuilder.Build();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/SpringContainerAdapter.cs
+++ b/IocPerformance/Adapters/SpringContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Spring.Context;
 
@@ -28,15 +29,15 @@ namespace IocPerformance.Adapters
             this.container = Spring.Context.Support.ContextRegistry.GetContext();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return (T)container.GetObject(typeof(T).FullName);
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetObject(type.FullName);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return (T)container.GetObject(typeof(T).FullName);
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetObject(type.FullName);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/StructureMapContainerAdapter.cs
+++ b/IocPerformance/Adapters/StructureMapContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using IocPerformance.Interception;
 using StructureMap;
@@ -38,15 +39,15 @@ namespace IocPerformance.Adapters
             });
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.GetInstance<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.GetInstance(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/TinyIOCContainerAdapter.cs
+++ b/IocPerformance/Adapters/TinyIOCContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using TinyIoC;
 
@@ -32,15 +33,15 @@ namespace IocPerformance.Adapters
             this.container.Register<ICombined, Combined>().AsMultiInstance();
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/UnityContainerAdapter.cs
+++ b/IocPerformance/Adapters/UnityContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Microsoft.Practices.Unity;
 using Microsoft.Practices.Unity.InterceptionExtension;
@@ -37,15 +38,15 @@ namespace IocPerformance.Adapters
               .SetInterceptorFor<ICalculator>(new InterfaceInterceptor());
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Adapters/WindsorContainerAdapter.cs
+++ b/IocPerformance/Adapters/WindsorContainerAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
@@ -36,15 +37,15 @@ namespace IocPerformance.Adapters
             this.container.Register(Component.For<ICalculator>().ImplementedBy<Calculator>().Interceptors<WindsorInterceptionLogger>().LifeStyle.Transient);
         }
 
-        public T Resolve<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object Resolve(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
-        public T ResolveProxy<T>() where T : class
-        {
-            return this.container.Resolve<T>();
-        }
+		public object ResolveProxy(Type type)
+		{
+			return this.container.Resolve(type);
+		}
 
         public void Dispose()
         {

--- a/IocPerformance/Program.cs
+++ b/IocPerformance/Program.cs
@@ -21,9 +21,9 @@ namespace IocPerformance
                 Tuple.Create<string, IContainerAdapter>("Catel", new CatelContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("Dynamo", new DynamoContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("fFastInjector", new FFastInjectorContainerAdapter()),
-                Tuple.Create<string, IContainerAdapter>("Funq", new FunqContainerAdapter()),
+				//Tuple.Create<string, IContainerAdapter>("Funq", new FunqContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("Griffin", new GriffinContainerAdapter()),
-                Tuple.Create<string, IContainerAdapter>("HaveBox", new HaveBoxContainerAdapter()),
+				//Tuple.Create<string, IContainerAdapter>("HaveBox", new HaveBoxContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("Hiro", new HiroContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("LightCore", new LightCoreContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("LightInject", new LightInjectContainerAdapter()),
@@ -35,7 +35,7 @@ namespace IocPerformance
                 Tuple.Create<string, IContainerAdapter>("Ninject", new NinjectContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("Petite", new PetiteContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("SimpleInjector", new SimpleInjectorContainerAdapter()),
-                Tuple.Create<string, IContainerAdapter>("Speedioc", new SpeediocContainerAdapter()),
+				//Tuple.Create<string, IContainerAdapter>("Speedioc", new SpeediocContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("Spring.NET", new SpringContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("StructureMap", new StructureMapContainerAdapter()),
                 Tuple.Create<string, IContainerAdapter>("TinyIOC", new TinyIOCContainerAdapter()),
@@ -99,15 +99,15 @@ namespace IocPerformance
 			for (int i = 0; i < LoopCount; i++)
 			{
 				singletonWatch.Start();
-				container.Resolve<ISingleton>();
+				var result1 = (ISingleton)container.Resolve(typeof(ISingleton));
 				singletonWatch.Stop();
 
 				transientWatch.Start();
-				container.Resolve<ITransient>();
+				var result2 = (ITransient)container.Resolve(typeof(ITransient));
 				transientWatch.Stop();
 
 				combinedWatch.Start();
-				container.Resolve<ICombined>();
+				var result3 = (ICombined)container.Resolve(typeof(ICombined));
 				combinedWatch.Stop();
 			}
 
@@ -120,7 +120,7 @@ namespace IocPerformance
 
 			for (int i = 0; i < LoopCount; i++)
 			{
-				container.ResolveProxy<ICalculator>();
+				var result = (ICalculator)container.ResolveProxy(typeof(ICalculator));
 			}
 
 			return watch.ElapsedMilliseconds;
@@ -139,13 +139,13 @@ namespace IocPerformance
 
 		private static void WarmUp(IContainerAdapter container)
 		{
-			var interface1 = container.Resolve<ISingleton>();
-			var interface2 = container.Resolve<ITransient>();
-			var combined = container.Resolve<ICombined>();
+			var interface1 = (ISingleton)container.Resolve(typeof(ISingleton));
+			var interface2 = (ITransient)container.Resolve(typeof(ITransient));
+			var combined = (ICombined)container.Resolve(typeof(ICombined));
 
 			if (container.SupportsInterception)
 			{
-				var calculator = container.ResolveProxy<ICalculator>();
+				var calculator = (ICalculator)container.ResolveProxy(typeof(ICalculator));
 				calculator.Add(1, 2);
 			}
 		}


### PR DESCRIPTION
Changed to resolve using Type instead of Generics, as this is the most basic and common way of resolving if you for an example use the IServiceProvider, System.Web.Mvc.IDepdencyResolver or System.Web.Http.IDependencyResolver for either MVC or WebApi. 
Basically the Type will always be used in any pluggable part of the .NET framework.
The Generic Resolve<T>() method is usually syntactic sugar wrapping the Resolve(Type) method, and is only used when you are manually resolving something - which you hopefully want to do as little of as possible.
