### PR TITLE
Conditional registrations for Simple Injector.

### DIFF
--- a/IocPerformance/Adapters/SimpleInjectorContainerAdapter.cs
+++ b/IocPerformance/Adapters/SimpleInjectorContainerAdapter.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq.Expressions;
 using IocPerformance.Classes.Complex;
+using IocPerformance.Classes.Conditions;
 using IocPerformance.Classes.Dummy;
 using IocPerformance.Classes.Generics;
 using IocPerformance.Classes.Multiple;
@@ -8,6 +10,7 @@ using IocPerformance.Interception;
 using SimpleInjector;
 using SimpleInjector.Extensions;
 using SimpleInjector.Extensions.Interception;
+using IocPerformance.Conditional;
 
 namespace IocPerformance.Adapters
 {
@@ -18,6 +21,11 @@ namespace IocPerformance.Adapters
         public override string PackageName
         {
             get { return "SimpleInjector"; }
+        }
+
+        public override bool SupportsConditional
+        {
+            get { return true; }
         }
 
         public override bool SupportGeneric
@@ -54,6 +62,7 @@ namespace IocPerformance.Adapters
             this.RegisterStandard();
             this.RegisterComplex();
             this.RegisterOpenGeneric();
+            this.RegisterConditional();
             this.RegisterMultiple();
             this.RegisterIntercepter();
 
@@ -97,6 +106,19 @@ namespace IocPerformance.Adapters
         {
             this.container.RegisterOpenGeneric(typeof(IGenericInterface<>), typeof(GenericExport<>));
             this.container.RegisterOpenGeneric(typeof(ImportGeneric<>), typeof(ImportGeneric<>));
+        }
+
+        private void RegisterConditional()
+        {
+            var container = this.container;
+
+            container.Register<ImportConditionObject>();
+            container.Register<ImportConditionObject2>();
+
+            container.RegisterWithContext<IExportConditionInterface>(context =>
+                context.ImplementationType == typeof(ImportConditionObject) 
+                    ? (IExportConditionInterface)container.GetInstance<ExportConditionalObject>()
+                    : (IExportConditionInterface)container.GetInstance<ExportConditionalObject2>());
         }
 
         private void RegisterMultiple()

--- a/IocPerformance/Conditional/SimpleInjectorContextDependentExtensions.cs
+++ b/IocPerformance/Conditional/SimpleInjectorContextDependentExtensions.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using SimpleInjector;
+
+namespace IocPerformance.Conditional
+{
+    // source: https://simpleinjector.codeplex.com/wikipage?title=Advanced-scenarios#Context-Based-Injection
+    public static class ContextDependentExtensions
+    {
+        public class DependencyContext
+        {
+            internal static readonly DependencyContext Root = new DependencyContext();
+
+            internal DependencyContext(Type serviceType, Type implementationType)
+            {
+                this.ServiceType = serviceType;
+                this.ImplementationType = implementationType;
+            }
+
+            private DependencyContext() { }
+
+            public Type ServiceType { get; private set; }
+            public Type ImplementationType { get; private set; }
+        }
+
+        public static void RegisterWithContext<TService>(this Container container,
+            Func<DependencyContext, TService> contextBasedFactory) where TService : class
+        {
+            if (contextBasedFactory == null) throw new ArgumentNullException("contextBasedFactory");
+
+            Func<TService> rootFactory = () => contextBasedFactory(DependencyContext.Root);
+
+            container.Register<TService>(rootFactory, Lifestyle.Transient);
+
+            // Allow the Func<DependencyContext, TService> to be 
+            // injected into parent types.
+            container.ExpressionBuilding += (sender, e) =>
+            {
+                if (e.RegisteredServiceType != typeof(TService))
+                {
+                    var rewriter = new DependencyContextRewriter
+                    {
+                        ServiceType = e.RegisteredServiceType,
+                        ContextBasedFactory = contextBasedFactory,
+                        RootFactory = rootFactory,
+                        Expression = e.Expression
+                    };
+
+                    e.Expression = rewriter.Visit(e.Expression);
+                }
+            };
+        }
+
+        private sealed class DependencyContextRewriter : ExpressionVisitor
+        {
+            internal Type ServiceType { get; set; }
+            internal object ContextBasedFactory { get; set; }
+            internal object RootFactory { get; set; }
+            internal Expression Expression { get; set; }
+
+            internal Type ImplementationType
+            {
+                get
+                {
+                    var expression = this.Expression as NewExpression;
+                    if (expression != null) return expression.Constructor.DeclaringType;
+                    return this.ServiceType;
+                }
+            }
+
+            protected override Expression VisitInvocation(
+                InvocationExpression node)
+            {
+                if (!this.IsRootedContextBasedFactory(node)) return base.VisitInvocation(node);
+
+                return Expression.Invoke(
+                    Expression.Constant(this.ContextBasedFactory),
+                    Expression.Constant(new DependencyContext(this.ServiceType, this.ImplementationType)));
+            }
+
+            private bool IsRootedContextBasedFactory(
+                InvocationExpression node)
+            {
+                var expression = node.Expression as ConstantExpression;
+
+                if (expression == null) return false;
+
+                return object.ReferenceEquals(expression.Value,
+                    this.RootFactory);
+            }
+        }
+    }
+}

--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -250,6 +250,7 @@
     <Compile Include="Classes\Standard\Combined.cs" />
     <Compile Include="Classes\Standard\Singleton.cs" />
     <Compile Include="Classes\Standard\Transient.cs" />
+    <Compile Include="Conditional\SimpleInjectorContextDependentExtensions.cs" />
     <Compile Include="ContainerAdapterFactory.cs" />
     <Compile Include="Interception\AutofacInterceptionLogger.cs" />
     <Compile Include="Interception\MugenInjectionInterceptionLogger.cs" />


### PR DESCRIPTION
Registrations added to the Simple Injector adapter to enable the
conditional benchmarks. The code contains the RegisterWithContext extension method that can be found at the Simple Injector wiki: https://simpleinjector.codeplex.com/wikipage?title=Advanced-scenarios#Context-Based-Injection.
