### PR TITLE
changed: ImportMultiple check to ensure each item creation.

### DIFF
--- a/IocPerformance/Classes/Multiple/ImportMultiple.cs
+++ b/IocPerformance/Classes/Multiple/ImportMultiple.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 
 namespace IocPerformance.Classes.Multiple
 {
@@ -16,7 +15,13 @@ namespace IocPerformance.Classes.Multiple
                 throw new ArgumentNullException("adapters");
             }
 
-            int adapterCount = adapters.Count();
+            int adapterCount = 0;
+            foreach (var adapter in adapters)
+            {
+                if (adapter == null)
+                    throw new ArgumentException("adapters item should be not null");
+                ++adapterCount;
+            }
 
             if (adapterCount != 5)
             {


### PR DESCRIPTION
Changed ImportMultiple check to ensure each item creation for fair comparison with No-Container behavior. For instance calling Enumerable.Count with LightInject won't lead to service creation and will just return known collection length.
