### PR TITLE
Added early release of abioc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /IocPerformance.userprefs
 /IocPerformance/bin
 /IocPerformance/obj
+/packages/abioc*
 /packages/Autofac*
 /packages/Castle.Core*
 /packages/Castle.Windsor*
@@ -42,6 +43,9 @@
 /packages/Fody*
 /packages/DryIoc*
 /packages/Microsoft.Composition*
+/packages/Microsoft.CodeAnalysis.Analyzers*
+/packages/Microsoft.CodeAnalysis.Common*
+/packages/Microsoft.CodeAnalysis.CSharp*
 /packages/Microsoft.Extensions.DependencyInjection*
 /packages/Microsoft.NETCore.Platforms*
 /packages/NETStandard.Library*

--- a/IocPerformance/Adapters/AbiocContainerAdapter.cs
+++ b/IocPerformance/Adapters/AbiocContainerAdapter.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Abioc;
+using IocPerformance.Classes.Complex;
+using IocPerformance.Classes.Dummy;
+using IocPerformance.Classes.Standard;
+
+namespace IocPerformance.Adapters
+{
+    public sealed class AbiocContainerAdapter : ContainerAdapterBase
+    {
+        private readonly DefaultContructionContext _contructionContext = new DefaultContructionContext();
+        private CompilationContext<DefaultContructionContext> _compilationContext;
+
+        public override string PackageName => "abioc";
+
+        public override string Url => "https://github.com/JSkimming/abioc";
+
+        public override object Resolve(Type type)
+        {
+            return _compilationContext.GetService(_contructionContext, type);
+        }
+
+        public override void Dispose()
+        {
+            // does not support cleanup
+        }
+
+        public override void PrepareBasic()
+        {
+            var registrationContext = new RegistrationContext<DefaultContructionContext>();
+
+            RegisterDummies(registrationContext);
+            RegisterStandard(registrationContext);
+            RegisterComplex(registrationContext);
+
+            _compilationContext = registrationContext.Compile(GetType().Assembly);
+        }
+
+        private static void RegisterDummies(RegistrationContext<DefaultContructionContext> registrationContext)
+        {
+            registrationContext
+                .Register<IDummyOne, DummyOne>()
+                .Register<IDummyTwo, DummyTwo>()
+                .Register<IDummyThree, DummyThree>()
+                .Register<IDummyFour, DummyFour>()
+                .Register<IDummyFive, DummyFive>()
+                .Register<IDummySix, DummySix>()
+                .Register<IDummySeven, DummySeven>()
+                .Register<IDummyEight, DummyEight>()
+                .Register<IDummyNine, DummyNine>()
+                .Register<IDummyTen, DummyTen>();
+        }
+
+        private static void RegisterStandard(RegistrationContext<DefaultContructionContext> registrationContext)
+        {
+            var singleton1 = new Singleton1();
+            var singleton2 = new Singleton2();
+            var singleton3 = new Singleton3();
+
+            registrationContext
+                .Register<ISingleton1>(c => singleton1)
+                .Register<ISingleton2>(c => singleton2)
+                .Register<ISingleton3>(c => singleton3)
+                .Register<ITransient1, Transient1>()
+                .Register<ITransient2, Transient2>()
+                .Register<ITransient3, Transient3>()
+                .Register<ICombined1, Combined1>()
+                .Register<ICombined2, Combined2>()
+                .Register<ICombined3, Combined3>();
+        }
+
+        private static void RegisterComplex(RegistrationContext<DefaultContructionContext> registrationContext)
+        {
+            var firstService = new FirstService();
+            var secondService = new SecondService();
+            var thirdService = new ThirdService();
+
+            registrationContext
+                .Register<IFirstService>(c => firstService)
+                .Register<ISecondService>(c => secondService)
+                .Register<IThirdService>(c => thirdService)
+                .Register<ISubObjectOne, SubObjectOne>()
+                .Register<ISubObjectTwo, SubObjectTwo>()
+                .Register<ISubObjectThree, SubObjectThree>()
+                .Register<IComplex1, Complex1>()
+                .Register<IComplex2, Complex2>()
+                .Register<IComplex3, Complex3>();
+        }
+    }
+}

--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -38,6 +38,10 @@
     <StartupObject>IocPerformance.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="abioc, Version=0.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\abioc.0.1.7\lib\net46\abioc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Autofac, Version=4.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.4.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
@@ -185,6 +189,14 @@
     <Reference Include="MicroSliver">
       <HintPath>..\packages\MicroSliver.2.1.6.0\lib\net40\MicroSliver.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.0.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.2.0.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
@@ -321,6 +333,14 @@
       <HintPath>..\packages\StyleMVVM.3.1.5\lib\net45\StyleMVVM.DotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
@@ -337,19 +357,43 @@
     <Reference Include="System.Composition.TypedParts">
       <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.1\lib\net46\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
@@ -371,6 +415,18 @@
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -382,8 +438,21 @@
       <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Adapters\AbiocContainerAdapter.cs" />
     <Compile Include="Adapters\AutofacContainerAdapter.cs" />
     <Compile Include="Adapters\CatelContainerAdapter.cs" />
     <Compile Include="Adapters\CaliburnMicroContainerAdapter.cs" />
@@ -582,6 +651,10 @@
       <LastGenOutput>Container.Generated.cs</LastGenOutput>
     </Content>
     <None Include="DryIocZero\Registrations.tt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IocPerformance</RootNamespace>
     <AssemblyName>IocPerformance</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -59,11 +59,11 @@
       <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
     <Reference Include="Catel.Core, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Catel.Core.4.5.4\lib\net45\Catel.Core.dll</HintPath>
+      <HintPath>..\packages\Catel.Core.4.5.4\lib\net46\Catel.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Catel.Extensions.Interception, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Catel.Extensions.Interception.4.5.4\lib\net45\Catel.Extensions.Interception.dll</HintPath>
+      <HintPath>..\packages\Catel.Extensions.Interception.4.5.4\lib\net46\Catel.Extensions.Interception.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
@@ -144,7 +144,7 @@
       <HintPath>..\packages\LightCore.1.5.1\lib\net40\LightCore.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="LightInject, Version=5.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\LightInject.5.0.2\lib\net45\LightInject.dll</HintPath>
+      <HintPath>..\packages\LightInject.5.0.2\lib\net46\LightInject.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="LightInject.Interception, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -339,16 +339,38 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.1\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -356,6 +378,10 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Adapters\AutofacContainerAdapter.cs" />

--- a/IocPerformance/app.config
+++ b/IocPerformance/app.config
@@ -59,6 +59,34 @@
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.FileVersionInfo" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <spring>
@@ -102,7 +130,7 @@
       <object id="calculatorTarget3" type="IocPerformance.Classes.Standard.Calculator3" singleton="false">
       </object>
       <object id="IocPerformance.Classes.Standard.ICalculator1" type="Spring.Aop.Framework.ProxyFactoryObject">
-        <property name="targetName" value="calculatorTarget1">          
+        <property name="targetName" value="calculatorTarget1">
         </property>
         <property name="isSingleton" value="false" />
         <property name="proxyInterfaces" value="IocPerformance.Classes.Standard.ICalculator1" />

--- a/IocPerformance/app.config
+++ b/IocPerformance/app.config
@@ -213,6 +213,6 @@
     <logging></logging>
   </common>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
 </configuration>

--- a/IocPerformance/packages.config
+++ b/IocPerformance/packages.config
@@ -6,8 +6,8 @@
   <package id="Caliburn.Micro.Container" version="1.5.2" targetFramework="net45" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net451" />
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
-  <package id="Catel.Core" version="4.5.4" targetFramework="net45" />
-  <package id="Catel.Extensions.Interception" version="4.5.4" targetFramework="net45" />
+  <package id="Catel.Core" version="4.5.4" targetFramework="net46" />
+  <package id="Catel.Extensions.Interception" version="4.5.4" targetFramework="net46" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
@@ -28,7 +28,7 @@
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
   <package id="IfInjector" version="0.8.1" targetFramework="net45" />
   <package id="LightCore" version="1.5.1" targetFramework="net4" />
-  <package id="LightInject" version="5.0.2" targetFramework="net451" />
+  <package id="LightInject" version="5.0.2" targetFramework="net46" />
   <package id="LightInject.Interception" version="2.0.0" targetFramework="net45" />
   <package id="LightInject.Microsoft.DependencyInjection" version="2.0.1" targetFramework="net45" />
   <package id="LinFu.Core" version="2.3.0.41559" targetFramework="net4" />
@@ -75,10 +75,10 @@
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
   <package id="System.IO" version="4.3.0" targetFramework="net45" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net45" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.3.1" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.1" targetFramework="net46" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
@@ -90,13 +90,17 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
   <package id="TinyIoC" version="1.3" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />

--- a/IocPerformance/packages.config
+++ b/IocPerformance/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="abioc" version="0.1.7" targetFramework="net46" />
   <package id="Autofac" version="4.4.0" targetFramework="net451" />
   <package id="Autofac.Extensions.DependencyInjection" version="4.0.0" targetFramework="net45" />
   <package id="Autofac.Extras.DynamicProxy" version="4.2.1" targetFramework="net451" />
@@ -38,6 +39,9 @@
   <package id="Maestro" version="1.5.4" targetFramework="net45" />
   <package id="Maestro.Interception.DynamicProxy" version="1.0.2" targetFramework="net45" />
   <package id="MicroSliver" version="2.1.6.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.0.0" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net45" />
@@ -67,15 +71,23 @@
   <package id="StructureMap" version="4.4.3" targetFramework="net45" />
   <package id="StructureMap.Microsoft.DependencyInjection" version="1.3.0" targetFramework="net451" />
   <package id="StyleMVVM" version="3.1.5" targetFramework="net45" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
   <package id="System.IO" version="4.3.0" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net45" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
   <package id="System.Net.Http" version="4.3.1" targetFramework="net46" />
@@ -83,6 +95,7 @@
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
@@ -95,13 +108,20 @@
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="TinyIoC" version="1.3" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
   <package id="Unity.Interception" version="4.0.1" targetFramework="net45" />


### PR DESCRIPTION
I'm working on a new IoC container called abioc. It's generating C# code and using Roslyn to compile it into an assembly.

Initial performance is promising, it's comparable to the _no container_ benchmark, currently it only supports basic functionality.

The latest version of the [Roslyn packages](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common/) target .NETStandard 1.3, wich is only compatible with .NET 4.6 and above, as a result, I've upgraded the IocPerformance project to .NET 4.6.

As I expand the functionality, I plan to use IocPerformance to determine whether new features have a detrimental affect on performance.