### PR TITLE
Ensure root services are resolve prior to running benchmarks

### DIFF
--- a/IocPerformance/ContainerAdapterRuntime.cs
+++ b/IocPerformance/ContainerAdapterRuntime.cs
@@ -31,6 +31,16 @@ namespace IocPerformance
             {
                 container.Prepare();
 
+                // Run each benchmark before start measuring to ensure that all root services has been resolved.
+                // Exclude the "Prepare" benchmarks as they dispose the container.
+                foreach (var benchmark in benchmarks.Where(b => !b.Name.StartsWith("Prepare")))
+                {
+                    if (benchmark.IsSupportedBy(container))
+                    {
+                        benchmark.Warmup(container);
+                    }
+                }
+
                 foreach (var benchmark in benchmarks)
                 {
                     var benchmarkResult = existingBenchmarkResults.SingleOrDefault(b => b.ContainerInfo.Name == container.Name && b.BenchmarkInfo.Name == benchmark.Name);


### PR DESCRIPTION
There is still a minor problem related to the fact that containers with less features has less root services, but I don't think we need to adjust for that at the moment as most of the top performing containers implements basically all features.