### PR TITLE
Rezolver 1.2 Update

### DIFF
--- a/IocPerformance/Adapters/RezolverContainerAdapter.cs
+++ b/IocPerformance/Adapters/RezolverContainerAdapter.cs
@@ -97,38 +97,38 @@ namespace IocPerformance.Adapters
 
         private static void RegisterComplexObject(ITargetContainer targets)
         {
-            targets.Register(new SingletonTarget(Target.ForType<FirstService>()), typeof(IFirstService));
-            targets.Register(new SingletonTarget(Target.ForType<SecondService>()), typeof(ISecondService));
-            targets.Register(new SingletonTarget(Target.ForType<ThirdService>()), typeof(IThirdService));
-            targets.Register(Target.ForType<SubObjectOne>(), typeof(ISubObjectOne));
-            targets.Register(Target.ForType<SubObjectTwo>(), typeof(ISubObjectTwo));
-            targets.Register(Target.ForType<SubObjectThree>(), typeof(ISubObjectThree));
-            targets.Register(Target.ForType<Complex1>(), typeof(IComplex1));
-            targets.Register(Target.ForType<Complex2>(), typeof(IComplex2));
-            targets.Register(Target.ForType<Complex3>(), typeof(IComplex3));
+            targets.RegisterSingleton<FirstService, IFirstService>();
+            targets.RegisterSingleton<SecondService, ISecondService>();
+            targets.RegisterSingleton<ThirdService, IThirdService>();
+            targets.RegisterType<SubObjectOne, ISubObjectOne>();
+            targets.RegisterType<SubObjectTwo, ISubObjectTwo>();
+            targets.RegisterType<SubObjectThree, ISubObjectThree>();
+            targets.RegisterType<Complex1, IComplex1>();
+            targets.RegisterType<Complex2, IComplex2>();
+            targets.RegisterType<Complex3, IComplex3>();
         }
 
         private static void RegisterPropertyInjection(ITargetContainer targets)
         {
             // this method is temporary till I add auto property injection - thinking I might do it as
             // an extension target that can be added to any other target (except another target)
-            targets.Register(new SingletonTarget(Target.ForType<ServiceA>()), typeof(IServiceA));
-            targets.Register(new SingletonTarget(Target.ForType<ServiceB>()), typeof(IServiceB));
-            targets.Register(new SingletonTarget(Target.ForType<ServiceC>()), typeof(IServiceC));
+            targets.RegisterSingleton<ServiceA, IServiceA>();
+            targets.RegisterSingleton<ServiceB, IServiceB>();
+            targets.RegisterSingleton<ServiceC, IServiceC>();
 
-            targets.Register(Target.ForType<SubObjectA>(DefaultMemberBindingBehaviour.Instance), typeof(ISubObjectA));
-            targets.Register(Target.ForType<SubObjectB>(DefaultMemberBindingBehaviour.Instance), typeof(ISubObjectB));
-            targets.Register(Target.ForType<SubObjectC>(DefaultMemberBindingBehaviour.Instance), typeof(ISubObjectC));
+            targets.RegisterType<SubObjectA, ISubObjectA>(DefaultMemberBindingBehaviour.Instance);
+            targets.RegisterType<SubObjectB, ISubObjectB>(DefaultMemberBindingBehaviour.Instance);
+            targets.RegisterType<SubObjectC, ISubObjectC>(DefaultMemberBindingBehaviour.Instance);
 
-            targets.Register(Target.ForType<ComplexPropertyObject1>(DefaultMemberBindingBehaviour.Instance), typeof(IComplexPropertyObject1));
-            targets.Register(Target.ForType<ComplexPropertyObject2>(DefaultMemberBindingBehaviour.Instance), typeof(IComplexPropertyObject2));
-            targets.Register(Target.ForType<ComplexPropertyObject3>(DefaultMemberBindingBehaviour.Instance), typeof(IComplexPropertyObject3));
+            targets.RegisterType<ComplexPropertyObject1, IComplexPropertyObject1>(DefaultMemberBindingBehaviour.Instance);
+            targets.RegisterType<ComplexPropertyObject2, IComplexPropertyObject2>(DefaultMemberBindingBehaviour.Instance);
+            targets.RegisterType<ComplexPropertyObject3, IComplexPropertyObject3>(DefaultMemberBindingBehaviour.Instance);
         }
 
         private static void RegisterOpenGeneric(ITargetContainer targets)
         {
-            targets.Register(Target.ForType(typeof(GenericExport<>)), typeof(IGenericInterface<>));
-            targets.Register(Target.ForType(typeof(ImportGeneric<>)), typeof(ImportGeneric<>));
+            targets.RegisterType(typeof(GenericExport<>), typeof(IGenericInterface<>));
+            targets.RegisterType(typeof(ImportGeneric<>), typeof(ImportGeneric<>));
         }
 
         private static void RegisterMultiple(ITargetContainer targets)
@@ -143,9 +143,9 @@ namespace IocPerformance.Adapters
                     Target.ForType<SimpleAdapterFive>()
                 },
             typeof(ISimpleAdapter));
-            targets.Register(Target.ForType<ImportMultiple1>());
-            targets.Register(Target.ForType<ImportMultiple2>());
-            targets.Register(Target.ForType<ImportMultiple3>());
+            targets.RegisterType<ImportMultiple1>();
+            targets.RegisterType<ImportMultiple2>();
+            targets.RegisterType<ImportMultiple3>();
         }
 
         public override IChildContainerAdapter CreateChildContainerAdapter()

--- a/IocPerformance/Adapters/RezolverContainerAdapter.cs
+++ b/IocPerformance/Adapters/RezolverContainerAdapter.cs
@@ -116,13 +116,13 @@ namespace IocPerformance.Adapters
             targets.RegisterSingleton<ServiceB, IServiceB>();
             targets.RegisterSingleton<ServiceC, IServiceC>();
 
-            targets.RegisterType<SubObjectA, ISubObjectA>(DefaultMemberBindingBehaviour.Instance);
-            targets.RegisterType<SubObjectB, ISubObjectB>(DefaultMemberBindingBehaviour.Instance);
-            targets.RegisterType<SubObjectC, ISubObjectC>(DefaultMemberBindingBehaviour.Instance);
+            targets.RegisterType<SubObjectA, ISubObjectA>(MemberBindingBehaviour.BindProperties);
+            targets.RegisterType<SubObjectB, ISubObjectB>(MemberBindingBehaviour.BindProperties);
+            targets.RegisterType<SubObjectC, ISubObjectC>(MemberBindingBehaviour.BindProperties);
 
-            targets.RegisterType<ComplexPropertyObject1, IComplexPropertyObject1>(DefaultMemberBindingBehaviour.Instance);
-            targets.RegisterType<ComplexPropertyObject2, IComplexPropertyObject2>(DefaultMemberBindingBehaviour.Instance);
-            targets.RegisterType<ComplexPropertyObject3, IComplexPropertyObject3>(DefaultMemberBindingBehaviour.Instance);
+            targets.RegisterType<ComplexPropertyObject1, IComplexPropertyObject1>(MemberBindingBehaviour.BindProperties);
+            targets.RegisterType<ComplexPropertyObject2, IComplexPropertyObject2>(MemberBindingBehaviour.BindProperties);
+            targets.RegisterType<ComplexPropertyObject3, IComplexPropertyObject3>(MemberBindingBehaviour.BindProperties);
         }
 
         private static void RegisterOpenGeneric(ITargetContainer targets)

--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -269,9 +269,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\QuickInject.1.0.0.12\lib\portable-net45+win\QuickInject.dll</HintPath>
     </Reference>
-    <Reference Include="Rezolver, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rezolver.1.1.71702.500\lib\netstandard1.1\Rezolver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Rezolver, Version=1.2.7050.900, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rezolver.1.2.7050.900\lib\net451\Rezolver.dll</HintPath>
     </Reference>
     <Reference Include="Rezolver.Microsoft.Extensions.DependencyInjection, Version=1.1.703.1800, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Rezolver.Microsoft.Extensions.DependencyInjection.1.1.703.1800\lib\net451\Rezolver.Microsoft.Extensions.DependencyInjection.dll</HintPath>

--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -190,9 +190,8 @@
       <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
@@ -272,9 +271,8 @@
     <Reference Include="Rezolver, Version=1.2.7050.900, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Rezolver.1.2.7050.900\lib\net451\Rezolver.dll</HintPath>
     </Reference>
-    <Reference Include="Rezolver.Microsoft.Extensions.DependencyInjection, Version=1.1.703.1800, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rezolver.Microsoft.Extensions.DependencyInjection.1.1.703.1800\lib\net451\Rezolver.Microsoft.Extensions.DependencyInjection.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Rezolver.Microsoft.Extensions.DependencyInjection, Version=1.2.7050.900, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rezolver.Microsoft.Extensions.DependencyInjection.1.2.7050.900\lib\netstandard1.1\Rezolver.Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
     <Reference Include="SimpleInjector, Version=4.0.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.4.0.0\lib\net45\SimpleInjector.dll</HintPath>

--- a/IocPerformance/app.config
+++ b/IocPerformance/app.config
@@ -57,7 +57,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/IocPerformance/packages.config
+++ b/IocPerformance/packages.config
@@ -54,7 +54,7 @@
   <package id="Ninject.Extensions.Interception.Linfu" version="3.2.0.0" targetFramework="net45" />
   <package id="Petite.Container" version="0.3.2" />
   <package id="QuickInject" version="1.0.0.12" targetFramework="net45" />
-  <package id="Rezolver" version="1.1.71702.500" targetFramework="net45" requireReinstallation="true" />
+  <package id="Rezolver" version="1.2.7050.900" targetFramework="net451" />
   <package id="Rezolver.Microsoft.Extensions.DependencyInjection" version="1.1.703.1800" targetFramework="net451" />
   <package id="SimpleInjector" version="4.0.0" targetFramework="net451" />
   <package id="SimpleInjector.Extensions.LifetimeScoping" version="4.0.0" targetFramework="net451" />

--- a/IocPerformance/packages.config
+++ b/IocPerformance/packages.config
@@ -40,7 +40,7 @@
   <package id="MicroSliver" version="2.1.6.0" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
   <package id="MugenInjection" version="3.5.1" targetFramework="net45" />
@@ -55,7 +55,7 @@
   <package id="Petite.Container" version="0.3.2" />
   <package id="QuickInject" version="1.0.0.12" targetFramework="net45" />
   <package id="Rezolver" version="1.2.7050.900" targetFramework="net451" />
-  <package id="Rezolver.Microsoft.Extensions.DependencyInjection" version="1.1.703.1800" targetFramework="net451" />
+  <package id="Rezolver.Microsoft.Extensions.DependencyInjection" version="1.2.7050.900" targetFramework="net451" />
   <package id="SimpleInjector" version="4.0.0" targetFramework="net451" />
   <package id="SimpleInjector.Extensions.LifetimeScoping" version="4.0.0" targetFramework="net451" />
   <package id="Speedioc" version="0.1.33" targetFramework="net45" />


### PR DESCRIPTION
Hi Daniel,

Submitting a pull request to ensure the RezolveContainerAdapter is compatible with [Rezolver 1.2](https://github.com/ZolutionSoftware/Rezolver/releases/tag/1.2.7050.900), which I've just pushed to Nuget.

This release changes a few APIs and adds a significant performance improvement for the Asp.Net Core MS DI Extensions.

I've also taken the liberty of rewriting much of the registration code to use the `.Register*` extension methods for `ITargetContainer`.

The performance in the Child Container bench is still quite poor because of the dynamic compilation that's performed by the container - every time it runs it's recompiling the delegates for each type registered in the child container from scratch as it's a new container.   This is something I'm planning on addressing in a future release.

Thanks for all your hard work!

Andras