### PR TITLE
Consider to similarity for class naming.

### DIFF
--- a/IocPerformance/Adapters/AutofacContainerAdapter.cs
+++ b/IocPerformance/Adapters/AutofacContainerAdapter.cs
@@ -199,10 +199,10 @@ namespace IocPerformance.Adapters
 
         private static void RegisterConditional(ContainerBuilder autofacContainerBuilder)
         {
-            autofacContainerBuilder.Register(c => new ExportConditionalObject()).Named<IExportConditionInterface>("ExportConditionalObject");
+            autofacContainerBuilder.Register(c => new ExportConditionalObject1()).Named<IExportConditionInterface>("ExportConditionalObject1");
             autofacContainerBuilder.Register(c => new ExportConditionalObject2()).Named<IExportConditionInterface>("ExportConditionalObject2");
             autofacContainerBuilder.Register(c => new ExportConditionalObject3()).Named<IExportConditionInterface>("ExportConditionalObject3");
-            autofacContainerBuilder.Register(c => new ImportConditionObject1(c.ResolveNamed<IExportConditionInterface>("ExportConditionalObject")));
+            autofacContainerBuilder.Register(c => new ImportConditionObject1(c.ResolveNamed<IExportConditionInterface>("ExportConditionalObject1")));
             autofacContainerBuilder.Register(c => new ImportConditionObject2(c.ResolveNamed<IExportConditionInterface>("ExportConditionalObject2")));
             autofacContainerBuilder.Register(c => new ImportConditionObject3(c.ResolveNamed<IExportConditionInterface>("ExportConditionalObject3")));
         }

--- a/IocPerformance/Adapters/DryIocAdapter.cs
+++ b/IocPerformance/Adapters/DryIocAdapter.cs
@@ -162,7 +162,7 @@ namespace IocPerformance.Adapters
             this.container.Register<ImportConditionObject2>();
             this.container.Register<ImportConditionObject3>();
 
-            this.container.Register<IExportConditionInterface, ExportConditionalObject>(
+            this.container.Register<IExportConditionInterface, ExportConditionalObject1>(
                 setup: Setup.With(condition: r => r.Parent.ImplementationType == typeof(ImportConditionObject1)));
 
             this.container.Register<IExportConditionInterface, ExportConditionalObject2>(

--- a/IocPerformance/Adapters/GraceContainerAdapter.cs
+++ b/IocPerformance/Adapters/GraceContainerAdapter.cs
@@ -104,7 +104,7 @@ namespace IocPerformance.Adapters
                     ioc.Export<ImportConditionObject2>();
                     ioc.Export<ImportConditionObject3>();
 
-                    ioc.Export<ExportConditionalObject>()
+                    ioc.Export<ExportConditionalObject1>()
                         .As<IExportConditionInterface>()
                         .When.InjectedInto<ImportConditionObject1>();
 

--- a/IocPerformance/Adapters/LightInjectContainerAdapter.cs
+++ b/IocPerformance/Adapters/LightInjectContainerAdapter.cs
@@ -143,10 +143,10 @@ namespace IocPerformance.Adapters
 
         private void RegisterConditional()
         {
-            this.container.Register<IExportConditionInterface, ExportConditionalObject>("ExportConditionalObject");
+            this.container.Register<IExportConditionInterface, ExportConditionalObject1>("ExportConditionalObject1");
             this.container.Register<IExportConditionInterface, ExportConditionalObject2>("ExportConditionalObject2");
             this.container.Register<IExportConditionInterface, ExportConditionalObject3>("ExportConditionalObject3");
-            this.container.Register(f => new ImportConditionObject1(f.GetInstance<IExportConditionInterface>("ExportConditionalObject")));
+            this.container.Register(f => new ImportConditionObject1(f.GetInstance<IExportConditionInterface>("ExportConditionalObject1")));
             this.container.Register(f => new ImportConditionObject2(f.GetInstance<IExportConditionInterface>("ExportConditionalObject2")));
             this.container.Register(f => new ImportConditionObject3(f.GetInstance<IExportConditionInterface>("ExportConditionalObject3")));
         }

--- a/IocPerformance/Adapters/MaestroContainerAdapter.cs
+++ b/IocPerformance/Adapters/MaestroContainerAdapter.cs
@@ -164,7 +164,7 @@ namespace IocPerformance.Adapters
                 .Use(x =>
                      {
                          x.If(ctx => ctx.TypeStack.Root == typeof(ImportConditionObject1))
-                             .Use<ExportConditionalObject>();
+                             .Use<ExportConditionalObject1>();
                          x.If(ctx => ctx.TypeStack.Root == typeof(ImportConditionObject2))
                              .Use<ExportConditionalObject2>();
                          x.If(ctx => ctx.TypeStack.Root == typeof(ImportConditionObject3))

--- a/IocPerformance/Adapters/MugenContainerAdapter.cs
+++ b/IocPerformance/Adapters/MugenContainerAdapter.cs
@@ -129,7 +129,7 @@ namespace IocPerformance.Adapters
             this.container.Bind<ImportConditionObject2>().To<ImportConditionObject2>().InTransientScope();
             this.container.Bind<ImportConditionObject3>().To<ImportConditionObject3>().InTransientScope();
             this.container.Bind<IExportConditionInterface>()
-                .To<ExportConditionalObject>()
+                .To<ExportConditionalObject1>()
                 .WhenIntoIsAssignable<ImportConditionObject1>()
                 .InTransientScope();
             this.container.Bind<IExportConditionInterface>()

--- a/IocPerformance/Adapters/NinjectContainerAdapter.cs
+++ b/IocPerformance/Adapters/NinjectContainerAdapter.cs
@@ -134,7 +134,7 @@ namespace IocPerformance.Adapters
             this.container.Bind<ImportConditionObject2>().To<ImportConditionObject2>().InTransientScope();
             this.container.Bind<ImportConditionObject3>().To<ImportConditionObject3>().InTransientScope();
             this.container.Bind<IExportConditionInterface>()
-                .To<ExportConditionalObject>()
+                .To<ExportConditionalObject1>()
                 .WhenInjectedInto<ImportConditionObject1>()
                 .InTransientScope();
             this.container.Bind<IExportConditionInterface>()

--- a/IocPerformance/Adapters/NoContainerAdapter.cs
+++ b/IocPerformance/Adapters/NoContainerAdapter.cs
@@ -189,7 +189,7 @@ namespace IocPerformance.Adapters
         private void RegisterConditional()
         {
             this.container[typeof(ImportConditionObject1)] =
-                () => new ImportConditionObject1(new ExportConditionalObject());
+                () => new ImportConditionObject1(new ExportConditionalObject1());
 
             this.container[typeof(ImportConditionObject2)] =
                 () => new ImportConditionObject2(new ExportConditionalObject2());

--- a/IocPerformance/Adapters/SimpleInjectorContainerAdapter.cs
+++ b/IocPerformance/Adapters/SimpleInjectorContainerAdapter.cs
@@ -148,7 +148,7 @@ namespace IocPerformance.Adapters
             this.container.Register<ImportConditionObject2>();
             this.container.Register<ImportConditionObject3>();
 
-            this.container.RegisterConditional<IExportConditionInterface, ExportConditionalObject>(this.WhenInjectedInto<ImportConditionObject1>);
+            this.container.RegisterConditional<IExportConditionInterface, ExportConditionalObject1>(this.WhenInjectedInto<ImportConditionObject1>);
             this.container.RegisterConditional<IExportConditionInterface, ExportConditionalObject2>(this.WhenInjectedInto<ImportConditionObject2>);
             this.container.RegisterConditional<IExportConditionInterface, ExportConditionalObject3>(this.WhenInjectedInto<ImportConditionObject3>);
         }

--- a/IocPerformance/Adapters/StashboxContainerAdapter.cs
+++ b/IocPerformance/Adapters/StashboxContainerAdapter.cs
@@ -158,7 +158,7 @@ namespace IocPerformance.Adapters
             this.container.RegisterType<ImportConditionObject1>();
             this.container.RegisterType<ImportConditionObject2>();
             this.container.RegisterType<ImportConditionObject3>();
-            this.container.RegisterType<IExportConditionInterface, ExportConditionalObject>(context => context
+            this.container.RegisterType<IExportConditionInterface, ExportConditionalObject1>(context => context
                 .WhenDependantIs<ImportConditionObject1>());
             this.container.RegisterType<IExportConditionInterface, ExportConditionalObject2>(context => context
                 .WhenDependantIs<ImportConditionObject2>());

--- a/IocPerformance/Classes/Conditional/ExportConditionalObject1.cs
+++ b/IocPerformance/Classes/Conditional/ExportConditionalObject1.cs
@@ -3,7 +3,7 @@
 namespace IocPerformance.Classes.Conditions
 {
     [PartCreationPolicy(CreationPolicy.NonShared)]
-    public class ExportConditionalObject : IExportConditionInterface
+    public class ExportConditionalObject1 : IExportConditionInterface
     {
     }
 }

--- a/IocPerformance/Classes/Conditional/ImportConditionObject1.cs
+++ b/IocPerformance/Classes/Conditional/ImportConditionObject1.cs
@@ -15,10 +15,10 @@ namespace IocPerformance.Classes.Conditions
                 throw new ArgumentNullException(nameof(exportConditionInterface));
             }
 
-            if (exportConditionInterface.GetType() != typeof(ExportConditionalObject))
+            if (exportConditionInterface.GetType() != typeof(ExportConditionalObject1))
             {
                 throw new ArgumentException(
-                    "Should have imported ExportConditionalObject got: " + exportConditionInterface.GetType().FullName,
+                    "Should have imported ExportConditionalObject1 got: " + exportConditionInterface.GetType().FullName,
 nameof(exportConditionInterface));
             }
 

--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -124,7 +124,7 @@
     <Compile Include="Classes\Complex\SubObjectThree.cs" />
     <Compile Include="Classes\Complex\SubObjectTwo.cs" />
     <Compile Include="Classes\Complex\ThirdService.cs" />
-    <Compile Include="Classes\Conditional\ExportConditionalObject.cs" />
+    <Compile Include="Classes\Conditional\ExportConditionalObject1.cs" />
     <Compile Include="Classes\Conditional\ExportConditionalObject2.cs" />
     <Compile Include="Classes\Conditional\ExportConditionalObject3.cs" />
     <Compile Include="Classes\Conditional\IExportConditionInterface.cs" />


### PR DESCRIPTION
In regard to make similarity in class naming, **ExportConditionalObject** class renamed to **ExportConditionalObject1**.