### PR TITLE
Upgrade to .NET Framework v4.7.2 for full compatibility with .NET Standard 2.0

### DIFF
--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>IocPerformance</RootNamespace>
     <AssemblyName>IocPerformance</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/IocPerformance/app.config
+++ b/IocPerformance/app.config
@@ -159,7 +159,7 @@
   <common>
     <logging></logging>
   </common>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+  </startup>
 </configuration>


### PR DESCRIPTION
Upgrading to .NET Framework v4.7.2 allows full compatibility with .NET Standard 2.0, earlier versions require additional packages.

See this post for more details.

> _Each successive version of full framework .NET has slightly better support for .NET Standard 2.0 up to 4.7.2 which now has full support for it and is the first version that can use .NET Standard 2.0 packages without bringing in extra dependencies._

https://weblog.west-wind.com/posts/2019/Feb/19/Using-NET-Standard-with-Full-Framework-NET#the-first-version-that-fully-net-standard-20-compliant-is-472

It's also the opinion of Immo Landwerth that v4.7.2 is the best version of the .NET Framework to target for .NET Standard compatibility.
> _If you want to consume .NET Standard 1.5+ from .NET Framework, I recommend to be on 4.7.2._

https://twitter.com/terrajobst/status/1031999730320986112?lang=en