### PR TITLE
Bumped to LightInject 6.1.0

### DIFF
--- a/IocPerformance/Adapters/LightInjectContainerAdapter.cs
+++ b/IocPerformance/Adapters/LightInjectContainerAdapter.cs
@@ -57,13 +57,12 @@ namespace IocPerformance.Adapters
         {
             ServiceCollection services = new ServiceCollection();
             this.RegisterAspNetCoreClasses(services);
-
             this.container.CreateServiceProvider(services);
         }
 
         public override void PrepareBasic()
         {
-            this.container = new ServiceContainer();
+            this.container = new ServiceContainer(o => o.EnableCurrentScope = false);
             this.RegisterBasic();
         }
 

--- a/IocPerformance/IocPerformance.csproj
+++ b/IocPerformance/IocPerformance.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -299,13 +300,13 @@
       <Version>1.5.1</Version>
     </PackageReference>
     <PackageReference Include="LightInject">
-      <Version>6.0.0</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
     <PackageReference Include="LightInject.Interception">
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="LightInject.Microsoft.DependencyInjection">
-      <Version>3.0.0</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="LinFu.Core">
       <Version>2.3.0.41559</Version>


### PR DESCRIPTION
This PR bumps LightInject to 6.1.0 and also adds a configuration option when creating the container. 