### PR TITLE
Remove warmup from benchmark

### DIFF
--- a/IocPerformance/ContainerAdapterRuntime.cs
+++ b/IocPerformance/ContainerAdapterRuntime.cs
@@ -31,16 +31,6 @@ namespace IocPerformance
             {
                 container.Prepare();
 
-                // Run each benchmark before start measuring to ensure that all root services has been resolved.
-                // Exclude the "Prepare" benchmarks as they dispose the container.
-                foreach (var benchmark in benchmarks.Where(b => !b.Name.StartsWith("Prepare")))
-                {
-                    if (benchmark.IsSupportedBy(container))
-                    {
-                        benchmark.Warmup(container);
-                    }
-                }
-
                 foreach (var benchmark in benchmarks)
                 {
                     var benchmarkResult = existingBenchmarkResults.SingleOrDefault(b => b.ContainerInfo.Name == container.Name && b.BenchmarkInfo.Name == benchmark.Name);


### PR DESCRIPTION
Warmup will result in caching of delegates and compiling of all expressions.
This will give containers with few features an unfair advantage over others.
  
I.e. warmup of 5 benchmarks will lead to for instance 20 cached entries.
A warmup of every benchmark will lead to 70, resulting in more hashcollissions	  
This will cause benchmarks to interfere with others. 
Removing the warmup will cause benchmarks to be more accurate